### PR TITLE
Added functionality to Etch A Sketch for resizing the grid and clearing the grid

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,12 +1,14 @@
 <!DOCTYPE html>
-<html>
+<html lang="en">
 <head>
     <meta charset="UTF-8">
+    <meta http-equiv="X-UA-Compatible" content="IE=edge">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Etch A Sketch</title>
     <link rel="stylesheet" href="style.css">
 </head>
 <body>
-    <h1>Etch A Sketch</h1>
+    <h1>Welcome to Etch A Sketch</h1>
     <div class="btn-container">
         <button class="btn" id="reset">Reset</button>
         <button class="btn" id="change-size">Change Size</button>

--- a/index.html
+++ b/index.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <meta charset="UTF-8">
+    <title>Etch A Sketch</title>
+    <link rel="stylesheet" href="style.css">
+</head>
+<body>
+    <h1>Etch A Sketch</h1>
+    <div class="btn-container">
+        <button class="btn" id="reset">Reset</button>
+        <button class="btn" id="change-size">Change Size</button>
+    </div>
+    <div id="container"></div>
+    <script src="script.js"></script>
+</body>
+</html>

--- a/script.js
+++ b/script.js
@@ -2,31 +2,31 @@ const container = document.querySelector("#container");
 const resetBtn = document.querySelector("#reset");
 const changeSizeBtn = document.querySelector("#change-size");
 
-function createGrid(size) {
-    const cellSize = 600 / size;
-    for (let i = 0; i < size * size; i++) {
-      const cell = document.createElement("div");
-      cell.classList.add("cell");
-      cell.style.width = `${cellSize}px`;
-      cell.style.height = `${cellSize}px`;
-      container.appendChild(cell);
-    }
-  
-    container.addEventListener("mouseover", (e) => {
-      if (e.target.className === "cell") {
-        e.target.style.backgroundColor = "grey";
-      }
-    });
+const createGrid = (size) => {
+  const cellSize = 600 / size;
+  for (let i = 0; i < size * size; i++) {
+    const cell = document.createElement("div");
+    cell.classList.add("cell");
+    cell.style.width = `${cellSize}px`;
+    cell.style.height = `${cellSize}px`;
+    container.appendChild(cell);
   }
 
-function resetGrid() {
+  container.addEventListener("mouseover", (e) => {
+    if (e.target.className === "cell") {
+      e.target.style.backgroundColor = "grey";
+    }
+  });
+};
+
+const resetGrid = () => {
   const cells = document.querySelectorAll(".cell");
   cells.forEach(function (cell) {
     cell.style.backgroundColor = "white";
   });
-}
+};
 
-function changeSize() {
+const changeSize = () => {
   let newSize = prompt("Enter a new size (maximum 100):");
   if (newSize === null) return;
   newSize = parseInt(newSize);
@@ -38,7 +38,7 @@ function changeSize() {
     container.innerHTML = "";
     createGrid(newSize);
   }
-}
+};
 
 document.addEventListener("DOMContentLoaded", () => {
   createGrid(16);

--- a/script.js
+++ b/script.js
@@ -1,18 +1,15 @@
 const container = document.querySelector("#container");
 const resetBtn = document.querySelector("#reset");
 const changeSizeBtn = document.querySelector("#change-size");
-resetBtn.addEventListener("click", resetGrid);
-changeSizeBtn.addEventListener("click", changeSize);
 
 function createGrid(size) {
-
   for (let i = 0; i < size * size; i++) {
     const cell = document.createElement("div");
     cell.classList.add("cell");
     container.appendChild(cell);
   }
 
-  container.addEventListener("mouseover", function (e) {
+  container.addEventListener("mouseover", (e) => {
     if (e.target.className === "cell") {
       e.target.style.backgroundColor = "grey";
     }
@@ -35,10 +32,14 @@ function changeSize() {
     changeSize();
   } else {
     resetGrid();
+    container.innerHTML = "";
     createGrid(newSize);
   }
 }
 
-document.addEventListener('DOMContentLoaded',()=>{
-    createGrid(16);
-})
+document.addEventListener("DOMContentLoaded", () => {
+  createGrid(16);
+});
+
+resetBtn.addEventListener("click", resetGrid);
+changeSizeBtn.addEventListener("click", changeSize);

--- a/script.js
+++ b/script.js
@@ -21,7 +21,7 @@ const createGrid = (size) => {
 
 const resetGrid = () => {
   const cells = document.querySelectorAll(".cell");
-  cells.forEach(function (cell) {
+  cells.forEach((cell) => {
     cell.style.backgroundColor = "white";
   });
 };

--- a/script.js
+++ b/script.js
@@ -1,0 +1,44 @@
+const container = document.querySelector("#container");
+const resetBtn = document.querySelector("#reset");
+const changeSizeBtn = document.querySelector("#change-size");
+resetBtn.addEventListener("click", resetGrid);
+changeSizeBtn.addEventListener("click", changeSize);
+
+function createGrid(size) {
+
+  for (let i = 0; i < size * size; i++) {
+    const cell = document.createElement("div");
+    cell.classList.add("cell");
+    container.appendChild(cell);
+  }
+
+  container.addEventListener("mouseover", function (e) {
+    if (e.target.className === "cell") {
+      e.target.style.backgroundColor = "grey";
+    }
+  });
+}
+
+function resetGrid() {
+  const cells = document.querySelectorAll(".cell");
+  cells.forEach(function (cell) {
+    cell.style.backgroundColor = "white";
+  });
+}
+
+function changeSize() {
+  let newSize = prompt("Enter a new size (maximum 100):");
+  if (newSize === null) return;
+  newSize = parseInt(newSize);
+  if (isNaN(newSize) || newSize > 100 || newSize < 1) {
+    alert("Please enter a valid number between 1 and 100.");
+    changeSize();
+  } else {
+    resetGrid();
+    createGrid(newSize);
+  }
+}
+
+document.addEventListener('DOMContentLoaded',()=>{
+    createGrid(16);
+})

--- a/script.js
+++ b/script.js
@@ -1,9 +1,11 @@
 const container = document.querySelector("#container");
 const resetBtn = document.querySelector("#reset");
 const changeSizeBtn = document.querySelector("#change-size");
+const containerSize = 600;
+const defaulsize = 16;
 
 const createGrid = (size) => {
-  const cellSize = 600 / size;
+  const cellSize = containerSize / size;
   for (let i = 0; i < size * size; i++) {
     const cell = document.createElement("div");
     cell.classList.add("cell");
@@ -41,7 +43,7 @@ const changeSize = () => {
 };
 
 document.addEventListener("DOMContentLoaded", () => {
-  createGrid(16);
+  createGrid(defaulsize);
 });
 
 resetBtn.addEventListener("click", resetGrid);

--- a/script.js
+++ b/script.js
@@ -3,18 +3,21 @@ const resetBtn = document.querySelector("#reset");
 const changeSizeBtn = document.querySelector("#change-size");
 
 function createGrid(size) {
-  for (let i = 0; i < size * size; i++) {
-    const cell = document.createElement("div");
-    cell.classList.add("cell");
-    container.appendChild(cell);
-  }
-
-  container.addEventListener("mouseover", (e) => {
-    if (e.target.className === "cell") {
-      e.target.style.backgroundColor = "grey";
+    const cellSize = 600 / size;
+    for (let i = 0; i < size * size; i++) {
+      const cell = document.createElement("div");
+      cell.classList.add("cell");
+      cell.style.width = `${cellSize}px`;
+      cell.style.height = `${cellSize}px`;
+      container.appendChild(cell);
     }
-  });
-}
+  
+    container.addEventListener("mouseover", (e) => {
+      if (e.target.className === "cell") {
+        e.target.style.backgroundColor = "grey";
+      }
+    });
+  }
 
 function resetGrid() {
   const cells = document.querySelectorAll(".cell");

--- a/style.css
+++ b/style.css
@@ -1,0 +1,53 @@
+* {
+  margin: 0;
+  padding: 0;
+  box-sizing: border-box;
+  font-family: system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto,
+    Oxygen, Ubuntu, Cantarell, "Open Sans", "Helvetica Neue", sans-serif;
+}
+
+body {
+  display: flex;
+  gap: 1rem;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+  height: 100vh;
+  margin: 0;
+}
+
+h1 {
+  text-align: center;
+}
+
+#container {
+  width: 500px;
+  height: 500px;
+  display: flex;
+  flex-wrap: wrap;
+  align-content: flex-start;
+}
+
+.cell {
+  width: calc(100% / 16);
+  height: calc(100% / 16);
+  box-sizing: border-box;
+  border: 1px solid black;
+  background-color: white;
+}
+
+.square {
+  background-color: white;
+  border: 1px solid black;
+}
+
+.btn {
+  margin-bottom: 10px;
+  border-radius: 1rem;
+  padding: 1rem 2rem;
+}
+
+.btn:hover {
+  background-color: rgb(75, 71, 71);
+  color: white;
+}

--- a/style.css
+++ b/style.css
@@ -21,16 +21,14 @@ h1 {
 }
 
 #container {
-  width: 500px;
-  height: 500px;
+  width: 600px;
+  height: 600px;
   display: flex;
   flex-wrap: wrap;
   align-content: flex-start;
 }
 
 .cell {
-  width: calc(100% / 16);
-  height: calc(100% / 16);
   box-sizing: border-box;
   border: 1px solid black;
   background-color: white;


### PR DESCRIPTION
# Description:
This PR adds new functionality to the Etch A Sketch web app. Users can now resize the grid up to a maximum of 100 by clicking the "Change Size" button and entering a number between 1 and 100. Additionally, there is a "Reset" button that clears the canvas and resets the grid back to its initial size of 16.

## Feature:
- Users can resize the grid by entering a number between 1 and 100.
- The "Reset" button clears the canvas and resets the grid back to its initial size of 16.

## Manual testing:
- Clicked on the "Reset" button and verified that the canvas was cleared and the grid was reset to its initial size of 16.
- Clicked on the "Change Size" button and entered a number between 1 and 100. Verified that the grid was resized accordingly.
- Entered an invalid number when prompted to change the grid size and verified that an error message was displayed.
- Moved the cursor over the cells in the grid and verified that they changed color to grey on mouseover.

live link:- https://sahnavin123.github.io/etch-a-sketch/
assignment link:- https://www.theodinproject.com/lessons/foundations-etch-a-sketch

## Page Images:-


| ![image](https://user-images.githubusercontent.com/95286412/235917494-877e296d-6a8c-4815-a678-47f90b0ba3a9.png) | ![image](https://user-images.githubusercontent.com/95286412/235917578-2eb2f31a-a166-44b0-bb58-2054f6c9d8c4.png)  |
|:-:|:-:|

